### PR TITLE
TIS-35: add dependabot configuration for Maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # keep Maven dependencies up to date with weekly checks to keep noise to minimal
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Why update libraries manually when we can make a computer do our work for us? :)

This is based on [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates). Dependabot's configuration is rather extensive, so probably a bit of documentation should be added as well?