### PR TITLE
TIS-36: add necessary minimal permissions for surefire test report publishing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  checks: write  # required by scacap/action-surefire-report
+  contents: read  # required by scacap/action-surefire-report
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows Dependabot to actually run its checks successfully.