### PR TITLE
TIS-68: restrict Jackson's coercion to prevent implicit primitive type coercions

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfiguration.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfiguration.java
@@ -1,0 +1,33 @@
+package fi.digitraffic.tis.vaco;
+
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * Customize Spring's internal Jackson facilities.
+ */
+@Configuration
+public class JacksonFeaturesConfiguration {
+
+    /**
+     * Set coercion of types to be as strict as possible.
+     *
+     * @return <code>Jackson2ObjectMapperBuilder</code> with strict {@link com.fasterxml.jackson.databind.cfg.CoercionConfig}
+     */
+    @Bean
+    public Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder() {
+        return new Jackson2ObjectMapperBuilder()
+                .postConfigurer((objectMapper -> {
+                    objectMapper.coercionConfigDefaults()
+                            .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail)
+                            .setCoercion(CoercionInputShape.Integer, CoercionAction.Fail)
+                            .setCoercion(CoercionInputShape.Float, CoercionAction.Fail)
+                            .setCoercion(CoercionInputShape.String, CoercionAction.Fail)
+                            .setCoercion(CoercionInputShape.Array, CoercionAction.Fail)
+                            .setCoercion(CoercionInputShape.Object, CoercionAction.Fail);
+                }));
+    }
+}

--- a/src/test/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfigurationTest.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfigurationTest.java
@@ -1,0 +1,51 @@
+package fi.digitraffic.tis.vaco;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import fi.digitraffic.tis.SpringBootIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JacksonFeaturesConfigurationTest extends SpringBootIntegrationTest {
+
+    private String primitiveValues = """
+            {
+              "notAnInteger": 123,
+              "notAFloat": 45.678,
+              "notABoolean": false
+            }
+            """;
+
+    record Tester(
+            String notAnInteger,
+            String notAFloat,
+            String notABoolean
+    ) {
+    }
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void willNotCoercePrimitivesToString() throws JsonProcessingException {
+        List.of("123", "45.6", "false", "true").forEach(primitive -> {
+            assertThrows(
+                    InvalidFormatException.class,
+                    () -> objectMapper.readValue(primitive, String.class),
+                    "Should have failed due to unwanted coercion");
+        });
+    }
+
+    @Test
+    void willNotCoercePrimitivePropertiesIntoStringFields() {
+        assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue(primitiveValues, Tester.class),
+                "Should have failed due to unwanted coercion");
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,5 @@
 # set database schema to be entirely driven by migrations
 spring.test.database.replace=none
+
+# Jackson feature configurations
+spring.jackson.mapper.allow-coercion-of-scalars=false


### PR DESCRIPTION
Primitive type coercion is slightly broken by default in Jackson and allows for automatic conversion of string-like values to strings unless otherwise configured. We don't like that since that would hide some of the validation errors, so this configuration blocks Jackson's implicit primitive type coercions.