### PR TITLE
do not use undertow web server because its underlying XNIO dependency causes segfault randomly on GitHub Actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,17 +110,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <!-- Exclude the Tomcat dependency -->
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
         <!-- Enable configuration classes -->
         <dependency>


### PR DESCRIPTION
Branch name is slightly misleading, out-of-box Jetty doesn't seem to work that well either, support is broken on Spring Boot's end. So, lets just use the default.