### PR TITLE
TIS-135: Add a CORS rule allowing cross-origin requests on /queue endpoint for…

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/VacoApplication.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/VacoApplication.java
@@ -3,6 +3,9 @@ package fi.digitraffic.tis.vaco;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
@@ -12,4 +15,13 @@ public class VacoApplication {
         SpringApplication.run(VacoApplication.class, args);
     }
 
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/queue").allowedOrigins("http://localhost:5173");
+            }
+        };
+    }
 }


### PR DESCRIPTION
… local development

For now don't have a better idea on how to handle this. Without either this kind of change or adding 

```java
@CrossOrigin(origins = "http://localhost:5173")
```
per endpoint action, it doesn't accept requests from front-end