### PR TITLE
reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "tmfg/digitraffic-tis-solita"


### PR DESCRIPTION
We don't need dependabot to be as excited as it currently is.