### PR TITLE
TIS-295/allow unknown RuleConfiguration ids to prevent breakage on entry submission

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfiguration.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/JacksonFeaturesConfiguration.java
@@ -1,11 +1,14 @@
 package fi.digitraffic.tis.vaco;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+;
 
 /**
  * Customize Spring's internal Jackson facilities.
@@ -26,6 +29,11 @@ public class JacksonFeaturesConfiguration {
             .postConfigurer(objectMapper -> {
                 // @JsonView made easy
                 objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, true);
+                // use nulls for unknown implementations to allow for relaxed matching of requested vs resolved
+                // RuleConfigurations
+                // Normally "fail fast" would be better, but as this relies on API users writing their types correctly,
+                // this is safer. User is expected to inspect the result of their entry submission anyways.
+                objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
                 // prevent coercion of anything to strings to allow Jakarta Validation to work as intended
                 objectMapper.coercionConfigDefaults()
                     .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail)


### PR DESCRIPTION
API users are instructed to inspect the result of their entry submission anyways, so blind submission without further handling is not meant to be a complete success anyway.