### PR TITLE
FINAP-210/enforce task_id+name uniqueness for packages

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/packages/PackagesRepository.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/packages/PackagesRepository.java
@@ -34,11 +34,13 @@ public class PackagesRepository {
         }
     }
 
-    public Package createPackage(Package p) {
+    public Package upsertPackage(Package p) {
         return jdbc.queryForObject("""
                 INSERT INTO package(task_id, path, name)
                      VALUES (?, ?, ?)
-                  RETURNING id, task_id, name, path
+                ON CONFLICT (task_id, name)
+                         DO UPDATE SET path = excluded.path
+                  RETURNING *
                 """,
             RowMappers.PACKAGE,
             p.taskId(), p.path(), p.name());

--- a/src/main/java/fi/digitraffic/tis/vaco/packages/PackagesService.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/packages/PackagesService.java
@@ -93,7 +93,7 @@ public class PackagesService {
      * @return Saved Package with updated ids, references etc.
      */
     public Package registerPackage(Package p) {
-        return packagesRepository.createPackage(p);
+        return packagesRepository.upsertPackage(p);
     }
 
     public List<Package> findPackages(Task task) {


### PR DESCRIPTION
This allows re-running tasks, as queue processing works on at least once semantics and in some cases has been duplicating rule runs