### PR TITLE
use ISO-8601 compatible timestamp for logging to allow better analysis...

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%.-10thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>%d{"yyyy-MM-dd' HH:mm:ss,SSS"} [%.-10thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{150} - %msg%n</pattern>
+            <pattern>%d{"yyyy-MM-dd' HH:mm:ss,SSS"} [%thread] %-5level %logger{150} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
…of logs in CloudWatch/ELK