### PR TITLE
TIS-443/update email template translations to use terminology as provided by …

### DIFF
--- a/src/main/resources/emails/entryCompleteEmail_en.properties
+++ b/src/main/resources/emails/entryCompleteEmail_en.properties
@@ -1,4 +1,4 @@
-email.subject=Ajo valmis
+email.subject=You have changed the data content of the APIs in the NAP service
 message.title=Ajo valmis
-message.body=Ajo valmis
-entry.link.text=Tarkasta ajon tulokset tästä
+message.body=The data content of your API has been validated and the dataset may also have been converted. The following is a report from the API content processing provided by Fintraffic?s validation and conversion service. If your API contains any errors, please correct your dataset and publish it again once it has been fixed.
+entry.link.text=View run report here

--- a/src/main/resources/emails/entryCompleteEmail_fi.properties
+++ b/src/main/resources/emails/entryCompleteEmail_fi.properties
@@ -1,4 +1,4 @@
-email.subject=Ajo valmis
+email.subject=Olette muuttaneet NAP-palvelussa olevien rajapintojen tietosisältöä
 message.title=Ajo valmis
-message.body=Ajo valmis
-entry.link.text=Tarkasta ajon tulokset tästä
+message.body=Rajapintanne tietosisältö on validoitu ja aineisto on mahdollisesti myös konvertoitu. Seuraavassa Fintrafficin validointi- ja konvertointipalvelun rajapintojen sisältökäsittelyn tuottama raportti. Mikäli rajapintanne sisältää virheitä (errors), korjatkaa aineistonne ja julkaiskaa se ehjänä uudelleen.
+entry.link.text=Tarkastele ajon raporttia tästä

--- a/src/main/resources/emails/entryCompleteEmail_sv.properties
+++ b/src/main/resources/emails/entryCompleteEmail_sv.properties
@@ -1,4 +1,4 @@
-email.subject=Ajo valmis
+email.subject=Ni har ändrat informationsinnehållet i gränssnitten i NAP-tjänsten
 message.title=Ajo valmis
-message.body=Ajo valmis
-entry.link.text=Tarkasta ajon tulokset tästä
+message.body=Informationsinnehållet i ert gränssnitt har validerats och materialet har eventuellt också konverterats. Nedan följer en rapport från Fintraffics validerings- och konverteringstjänst om behandlingen av gränssnittens innehåll. Om ert gränssnitt innehåller fel (errors), korrigera ert material och publicera det som fullständigt på nytt.
+entry.link.text=Granska körningsrapporten här

--- a/src/main/resources/emails/feedStatusEmail_en.properties
+++ b/src/main/resources/emails/feedStatusEmail_en.properties
@@ -1,8 +1,8 @@
-email.subject=Weekly report
-message.title=Here is your weekly report
-message.body=Latest feed reports:
-message.feeds.labels.feed=Feed
+email.subject=Status report of the APIs you have reported to NAP
+message.title=Status report of the APIs you have reported to NAP
+message.body=You have reported the following traffic service APIs to the NAP service. The following is a regular status report provided by Fintraffic?s validation and conversion service on the content of your APIs and the quality of your datasets. If your APIs contain any content and/or quality-related deficiencies, please correct your publication.
+message.feeds.labels.feed=Input
 message.feeds.labels.format=Format
 message.feeds.labels.badge=Run result
-message.feeds.labels.link=Link
-message.feeds.entries.link=Open in VACO UI
+message.feeds.labels.link=View in VACO UI
+message.feeds.entries.link=View in VACO UI

--- a/src/main/resources/emails/feedStatusEmail_fi.properties
+++ b/src/main/resources/emails/feedStatusEmail_fi.properties
@@ -1,8 +1,8 @@
-email.subject=Viikkoraportti
-message.title=Tässä viikkoraporttisi
-message.body=Viimeisimmät syöteraportit:
+email.subject=NAP:iin ilmoittamienne rajapintojen tilanneraportti
+message.title=NAP:iin ilmoittamienne rajapintojen tilanneraportti
+message.body=Olette ilmoittaneet NAP-palveluun seuraavat liikennepalveluiden rajapinnat. Seuraavassa Fintrafficin validointi- ja konvertointipalvelun säännöllinen tilanneraportti rajapintojen sisällöstä ja aineistojen laadusta. Korjatkaa julkaisunne, mikäli rajapinnoissanne on sisältö ja/tai laatupuutteita.
 message.feeds.labels.feed=Syöte
 message.feeds.labels.format=Formaatti
 message.feeds.labels.badge=Ajon tulos
-message.feeds.labels.link=Linkki
+message.feeds.labels.link=Tarkastele VACO UI:ssa
 message.feeds.entries.link=Tarkastele VACO UI:ssa

--- a/src/main/resources/emails/feedStatusEmail_sv.properties
+++ b/src/main/resources/emails/feedStatusEmail_sv.properties
@@ -1,8 +1,8 @@
-email.subject=Weekly report (untranslated)
-message.title=Here is your weekly report (untranslated)
-message.body=Latest feed reports: (untranslated)
-message.feeds.labels.feed=Feed (untranslated)
-message.feeds.labels.format=Format (untranslated)
-message.feeds.labels.badge=Run result (untranslated)
-message.feeds.labels.link=Link (untranslated)
-message.feeds.entries.link=Open in VACO UI (untranslated)
+email.subject=Lägesrapport över de gränssnitt ni meddelat till NAP
+message.title=Lägesrapport över de gränssnitt ni meddelat till NAP
+message.body=Ni har meddelat gränssnitt för följande trafiktjänster till NAP-tjänsten. Nedan följer Fintraffics regelbundna lägesrapport om gränssnittens innehåll och materialens kvalitet. Korrigera er publikation om det finns brister i innehållet och/eller kvaliteten i era gränssnitt.
+message.feeds.labels.feed=Indata
+message.feeds.labels.format=Format
+message.feeds.labels.badge=Körningens resultat
+message.feeds.labels.link=Granska i VACO UI
+message.feeds.entries.link=Granska i VACO UI

--- a/src/test/java/fi/digitraffic/tis/vaco/email/EmailServiceTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/email/EmailServiceTests.java
@@ -169,7 +169,7 @@ class EmailServiceTests extends AwsIntegrationTestBase {
                 equalTo(org.contactEmails()))
             );
         String message = list(path(messages, "messages[].Body.html_part"), JsonNode::textValue).get(0);
-        assertThat(message, containsString("<title>Viikkoraportti</title>"));
+        assertThat(message, containsString("<title>NAP:iin ilmoittamienne rajapintojen tilanneraportti</title>"));
     }
 
     @NotNull


### PR DESCRIPTION
…the translation agency

There was one typo in Swedish translation and I think we need to see these at least once and probably adjust a bit, but that can wait until user acceptance in a few weeks.