### PR TITLE
remove caching from findEntry methods as that causes incomplete entries in cache

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/queuehandler/QueueHandlerService.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/queuehandler/QueueHandlerService.java
@@ -120,9 +120,11 @@ public class QueueHandlerService {
     }
 
     public Optional<Entry> findEntry(String publicId, boolean skipErrorsField) {
-        return cachingService.cacheEntry(
-            cachingService.keyForEntry(publicId, skipErrorsField),
-            key -> entryRepository.findByPublicId(publicId, skipErrorsField).orElse(null));
+        return entryRepository.findByPublicId(publicId, skipErrorsField)
+            .map(e -> {
+                cachingService.invalidateEntry(e);
+                return e;
+            });
     }
 
     public Entry getEntry(String publicId, boolean skipErrorsField) {


### PR DESCRIPTION
General implication is that "find" means "go to database to look for latest"