### PR TITLE
TIS-535/add missing clauses to ruleset union SQL which probably were accidentally missed and never completed

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/ruleset/RulesetRepository.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/ruleset/RulesetRepository.java
@@ -128,6 +128,8 @@ public class RulesetRepository {
                   FROM ruleset r, parents, specific_rulesets
                  WHERE r.owner_id IN (parents.id)
                    AND r.category = 'generic'
+                   AND r.type = :type
+                   AND r.format = (:format)::transit_data_format
                 """,
             new MapSqlParameterSource()
                 .addValue("businessId", businessId)


### PR DESCRIPTION
This caused too many rules to be included into execution for non-root companies (e.g. Waltti) which then caused further problems during execution