### PR TITLE
deadletter_message_fix

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/rules/RuleResultsListener.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/RuleResultsListener.java
@@ -185,7 +185,7 @@ public class RuleResultsListener extends SqsListener {
                     .publicId(e)
                     .source(taskName.get())
                     .taskId(t)
-                    .message("Entry ended up in Dead Letter Queue")
+                    .message("entry_ended_up_in_dead_letter_queue")
                     .severity(FindingSeverity.ERROR)
                     .build());
             } else {

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/RuleResultsListenerTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/RuleResultsListenerTests.java
@@ -189,7 +189,7 @@ class RuleResultsListenerTests {
             .publicId(entry.publicId())
             .source(task.name())
             .taskId(2L)
-            .message("Entry ended up in Dead Letter Queue")
+            .message("entry_ended_up_in_dead_letter_queue")
             .severity(FindingSeverity.ERROR)
             .build();
 


### PR DESCRIPTION
Fix dead letter queue finding message to not contain whitespace so it works without crashing in ui