### PR TITLE
Limit SQS batch size to 10 messages

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/messaging/MessagingService.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/messaging/MessagingService.java
@@ -75,7 +75,7 @@ public class MessagingService {
     public Stream<Message> readMessages(String queueName) {
         ReceiveMessageRequest receiveMessageRequest = ReceiveMessageRequest.builder()
             .queueUrl(resolveQueueUrl(queueName))
-            .maxNumberOfMessages(Runtime.getRuntime().availableProcessors())
+            .maxNumberOfMessages(Math.min(10, Runtime.getRuntime().availableProcessors()))
             .waitTimeSeconds(1)
             .build();
 


### PR DESCRIPTION
SQS has a limit of 10 messages in a single batch