### PR TITLE
Adjust Hikari logging to monitor pool usage

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -29,6 +29,3 @@ vaco.ms-graph.client-secret=${TIS_VACO_MSGRAPH_CLIENT_SECRET}
 vaco.ms-graph.group-schema-extension=${TIS_VACO_MSGRAPH_SCHEMA_EXTENSION}
 
 springdoc.swagger-ui.persist-authorization=true
-
-logging.level.com.zaxxer.hikari.HikariConfig=DEBUG
-logging.level.com.zaxxer.hikari=TRACE

--- a/src/main/resources/application-tst.properties
+++ b/src/main/resources/application-tst.properties
@@ -2,8 +2,6 @@ spring.config.import=aws-secretsmanager:/database/password/vaco?prefix=vacodb.;/
 spring.datasource.driver-class-name=com.amazonaws.secretsmanager.sql.AWSSecretsManagerPostgreSQLDriver
 spring.datasource.url=jdbc-secretsmanager:postgresql://${vacodb.host}:${vacodb.port}/${vacodb.dbname}?currentSchema=${vacodb.dbname}
 spring.datasource.username=/database/password/vaco
-spring.datasource.hikari.leak-detection-threshold=2000
-spring.datasource.hikari.maximum-pool-size=20
 
 spring.mvc.static-path-pattern=/static/**
 spring.web.resources.static-locations=classpath:/public/
@@ -17,6 +15,3 @@ vaco.base-url=https://validator-test.fintraffic.fi
 vaco.scheduling.weekly-feed-status.cron=0 0 7 * * MON
 vaco.scheduling.cleanup.cron=0 0 10 * * *
 vaco.scheduling.refresh-statistics.cron=0 0 9 * * *
-
-logging.level.com.zaxxer.hikari.HikariConfig=DEBUG
-logging.level.com.zaxxer.hikari=TRACE

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,3 +60,8 @@ spring.cloud.azure.compatibility-verifier.enabled=false
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://login.microsoftonline.com/${vaco.azure-ad.tenant-id}/v2.0/keys
 spring.security.oauth2.resourceserver.jwt.issuer-uri=https://login.microsoftonline.com/${vaco.azure-ad.tenant-id}/v2.0
 spring.cloud.azure.active-directory.enabled=true
+
+# Log Hikari pool stats for better monitoring of used connections and slow queries
+spring.datasource.hikari.leak-detection-threshold=2000
+logging.level.com.zaxxer.hikari.HikariConfig=INFO
+logging.level.com.zaxxer.hikari.pool.HikariPool=DEBUG


### PR DESCRIPTION
# Changes
* Revert tst pool size to default (10)
* Use common Hikari-logging preferences in all environments
  * Pool usage (DEBUG)
  * Long running queries (leakage detection)