### PR TITLE
Dpo 4549: fix log exception logic

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
@@ -43,10 +43,19 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class RuleResultProcessor implements ResultProcessor {
+    /**
+     * Matches SLF4J/Logback log lines at non-error levels: {@code [thread] INFO|DEBUG|TRACE|WARN}.
+     * Lines matching this pattern are excluded from exception scanning — "Exception" in such lines
+     * appears in a class name, not as an actual runtime error.
+     */
+    private static final Pattern NON_ERROR_LOG_PATTERN =
+        Pattern.compile("\\[\\S+\\]\\s+(INFO|DEBUG|TRACE|WARN)\\s+");
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final PackagesService packagesService;
     private final S3Client s3Client;
@@ -74,6 +83,10 @@ public abstract class RuleResultProcessor implements ResultProcessor {
         this.objectMapper = Objects.requireNonNull(objectMapper);
     }
 
+    static boolean isNonErrorLogLine(String line) {
+        return NON_ERROR_LOG_PATTERN.matcher(line).find();
+    }
+
     @Override
     public boolean processResults(ResultMessage resultMessage, Entry entry, Task task) {
         Map<String, String> fileNames = collectOutputFileNames(resultMessage);
@@ -84,7 +97,6 @@ public abstract class RuleResultProcessor implements ResultProcessor {
     private void scanDebugLogs(ResultMessage resultMessage, Entry entry, Task task, Map<String, String> fileNames) {
         processLog(resultMessage, entry, task, fileNames, "stderr.log", "Exception");
         processLog(resultMessage, entry, task, fileNames, "stdout.log", "Exception");
-
     }
 
     abstract boolean doProcessResults(ResultMessage resultMessage, Entry entry, Task task, Map<String, String> fileNames);
@@ -223,7 +235,7 @@ public abstract class RuleResultProcessor implements ResultProcessor {
             try (Stream<String> reportLines = Files.lines(reportsFile)) {
 
                 return reportLines.map(errorLine -> {
-                        if (errorLine.contains(errorMarker)) {
+                        if (errorLine.contains(errorMarker) && !isNonErrorLogLine(errorLine)) {
                             String errorDetail = errorLine.substring(errorLine.indexOf(":") + 1).trim();
                             Map<String, String> errorMap = Map.of(errorMarker, errorDetail);
                             try {

--- a/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -283,48 +282,6 @@ public abstract class RuleResultProcessor implements ResultProcessor {
                 throw new RuleExecutionException("Stdout.log file could not be read into findings in entry " + entry.publicId());
             }
         });
-    }
-
-    protected List<ImmutableFinding> scanLog(Entry entry, Task task, String ruleName, Path reportsFile, String errorMarker) throws IOException {
-
-        try {
-            Long rulesetId = rulesetService.findByName(ruleName)
-                .orElseThrow(() -> new UnknownEntityException(ruleName, "Unknown rule name"))
-                .id();
-            try (Stream<String> reportLines = Files.lines(reportsFile)) {
-
-                return reportLines.map(errorLine -> {
-                        if (errorLine.startsWith(errorMarker)) {
-                            String errorDetail = errorLine.substring(errorLine.indexOf(":") + 1).trim();
-                            Map<String, String> errorMap = new HashMap<>();
-                            errorMap.put(errorMarker, errorDetail);
-                            try {
-                                return ImmutableFinding.of(
-                                        task.id(),
-                                        rulesetId,
-                                        ruleName,
-                                        errorMarker,
-                                        FindingSeverity.ERROR
-                                    )
-                                    .withRaw(objectMapper.writeValueAsBytes(errorMap));
-                            } catch (JsonProcessingException e) {
-                                logger.warn("Failed to convert tree to bytes", e);
-                                return null;
-                            }
-
-                        } else {
-                            return null;
-                        }
-
-                    })
-                    .filter(Objects::nonNull)
-                    .toList();
-            }
-
-        } catch (IOException e) {
-            logger.warn("Failed to process {}/{}/{} output file", entry.publicId(), task.name(), ruleName, e);
-            return List.of();
-        }
     }
 
     protected void requiredFilesNotFound(Entry entry, Task task, Set<String> filesFound){

--- a/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessor.java
@@ -116,8 +116,6 @@ public abstract class RuleResultProcessor implements ResultProcessor {
     protected Set<String> createOutputPackages(ResultMessage resultMessage, Entry entry, Task task, Set<String> requiredFiles) {
         // package generation based on rule outputs
         ConcurrentMap<String, List<String>> packagesToCreate = collectPackageContents(resultMessage.uploadedFiles());
-
-        packagesToCreate.forEach((packageName, files) -> createOutputPackage(entry, task, packageName, files));
         Set<String> uploadedFileNames = new HashSet<>();
 
         for (String url : resultMessage.uploadedFiles().keySet()) {

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/results/NetexToGtfsRuleResultProcessorTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/results/NetexToGtfsRuleResultProcessorTests.java
@@ -1,0 +1,149 @@
+package fi.digitraffic.tis.vaco.rules.results;
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.digitraffic.tis.aws.s3.S3Client;
+import fi.digitraffic.tis.vaco.TestObjects;
+import fi.digitraffic.tis.vaco.configuration.VacoProperties;
+import fi.digitraffic.tis.vaco.findings.FindingService;
+import fi.digitraffic.tis.vaco.findings.model.Finding;
+import fi.digitraffic.tis.vaco.findings.model.FindingSeverity;
+import fi.digitraffic.tis.vaco.process.model.ImmutableTask;
+import fi.digitraffic.tis.vaco.process.model.Task;
+import fi.digitraffic.tis.vaco.queuehandler.model.Entry;
+import fi.digitraffic.tis.vaco.rules.RuleName;
+import fi.digitraffic.tis.vaco.rules.model.ResultMessage;
+import fi.digitraffic.tis.vaco.ruleset.RulesetService;
+import fi.digitraffic.tis.vaco.ruleset.model.Category;
+import fi.digitraffic.tis.vaco.ruleset.model.ImmutableRuleset;
+import fi.digitraffic.tis.vaco.ruleset.model.RulesetType;
+import fi.digitraffic.tis.vaco.ruleset.model.TransitDataFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static fi.digitraffic.tis.vaco.rules.ResultProcessorTestHelpers.asResultMessage;
+import static fi.digitraffic.tis.vaco.rules.ResultProcessorTestHelpers.entryWithTask;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class NetexToGtfsRuleResultProcessorTests extends ResultProcessorTestBase {
+
+    @Mock private S3Client s3Client;
+    @Mock private FindingService findingService;
+    @Mock private RulesetService rulesetService;
+
+    @Captor private ArgumentCaptor<List<Finding>> capturedFindings;
+
+    private NetexToGtfsRuleResultProcessor resultProcessor;
+    private Entry entry;
+    private Task task;
+    private ImmutableRuleset netex2gtfsRuleset;
+
+    private final Map<String, Path> tempFiles = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        VacoProperties vacoProperties = TestObjects.vacoProperties();
+        resultProcessor = new NetexToGtfsRuleResultProcessor(
+            vacoProperties,
+            packagesService,
+            s3Client,
+            taskService,
+            findingService,
+            rulesetService,
+            new ObjectMapper()) {
+            @Override
+            protected Path downloadFile(Map<String, String> fileNames, String fileName, Path outputDir) {
+                return tempFiles.get(fileName);
+            }
+        };
+        entry = entryWithTask(e -> ImmutableTask.of(RuleName.NETEX2GTFS_ENTUR, 100)
+            .withId(9_000_000L)
+            .withPublicId(NanoIdUtils.randomNanoId()));
+        task = entry.tasks().get(0);
+        netex2gtfsRuleset = ImmutableRuleset.of(
+                RuleName.NETEX2GTFS_ENTUR,
+                "netex2gtfs",
+                Category.GENERIC,
+                RulesetType.CONVERSION_SYNTAX,
+                TransitDataFormat.NETEX)
+            .withId(42L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(findingService, rulesetService);
+    }
+
+    @Test
+    void stdoutLog_withInfoLevelExceptionLines_producesNoFailureFindings(@TempDir Path tempDir) throws IOException {
+        Path stdoutLog = tempDir.resolve("stdout.log");
+        Files.writeString(stdoutLog,
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.RouteNameException\n" +
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.DirectionNameException\n" +
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.AlternateStopNameException\n");
+        Path stderrLog = tempDir.resolve("stderr.log");
+        Files.writeString(stderrLog, "");
+        tempFiles.put("stdout.log", stdoutLog);
+        tempFiles.put("stderr.log", stderrLog);
+        ResultMessage resultMessage = asResultMessage(TestObjects.vacoProperties(), RuleName.NETEX2GTFS_ENTUR, entry, Map.of(
+            "stdout.log", List.of("debug"),
+            "stderr.log", List.of("debug"),
+            "result.zip", List.of("result")
+        ));
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+        given(findingService.reportFindings(capturedFindings.capture())).willReturn(true);
+        given(s3Client.copyFile(any(), any(), any(), any())).willReturn(CompletableFuture.completedFuture(null));
+
+        resultProcessor.processResults(resultMessage, entry, task);
+
+        assertThat(capturedFindings.getValue(), empty());
+    }
+
+    @Test
+    void stdoutLog_withErrorLevelExceptionLine_producesFailureFinding(@TempDir Path tempDir) throws IOException {
+        Path stdoutLog = tempDir.resolve("stdout.log");
+        Files.writeString(stdoutLog,
+            "12:00.000 [main] ERROR org.onebusaway.SomeClass -- OperatingPeriodException: period not found\n");
+        Path stderrLog = tempDir.resolve("stderr.log");
+        Files.writeString(stderrLog, "");
+        tempFiles.put("stdout.log", stdoutLog);
+        tempFiles.put("stderr.log", stderrLog);
+        ResultMessage resultMessage = asResultMessage(TestObjects.vacoProperties(), RuleName.NETEX2GTFS_ENTUR, entry, Map.of(
+            "stdout.log", List.of("debug"),
+            "stderr.log", List.of("debug"),
+            "result.zip", List.of("result")
+        ));
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+        given(findingService.reportFindings(capturedFindings.capture())).willReturn(true);
+        given(s3Client.copyFile(any(), any(), any(), any())).willReturn(CompletableFuture.completedFuture(null));
+
+        resultProcessor.processResults(resultMessage, entry, task);
+
+        List<Finding> findings = capturedFindings.getValue();
+        assertThat(findings, hasSize(1));
+        assertThat(findings.get(0).severity(), equalTo(FindingSeverity.FAILURE));
+    }
+}

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessorTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/results/RuleResultProcessorTests.java
@@ -1,0 +1,202 @@
+package fi.digitraffic.tis.vaco.rules.results;
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.digitraffic.tis.aws.s3.S3Client;
+import fi.digitraffic.tis.vaco.TestObjects;
+import fi.digitraffic.tis.vaco.configuration.VacoProperties;
+import fi.digitraffic.tis.vaco.findings.FindingService;
+import fi.digitraffic.tis.vaco.findings.model.ImmutableFinding;
+import fi.digitraffic.tis.vaco.packages.PackagesService;
+import fi.digitraffic.tis.vaco.process.TaskService;
+import fi.digitraffic.tis.vaco.process.model.ImmutableTask;
+import fi.digitraffic.tis.vaco.process.model.Task;
+import fi.digitraffic.tis.vaco.queuehandler.model.Entry;
+import fi.digitraffic.tis.vaco.rules.RuleName;
+import fi.digitraffic.tis.vaco.rules.model.ResultMessage;
+import fi.digitraffic.tis.vaco.ruleset.RulesetService;
+import fi.digitraffic.tis.vaco.ruleset.model.Category;
+import fi.digitraffic.tis.vaco.ruleset.model.ImmutableRuleset;
+import fi.digitraffic.tis.vaco.ruleset.model.RulesetType;
+import fi.digitraffic.tis.vaco.ruleset.model.TransitDataFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static fi.digitraffic.tis.vaco.rules.ResultProcessorTestHelpers.entryWithTask;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RuleResultProcessorTests {
+
+    @Mock private PackagesService packagesService;
+    @Mock private S3Client s3Client;
+    @Mock private TaskService taskService;
+    @Mock private FindingService findingService;
+    @Mock private RulesetService rulesetService;
+
+    private RuleResultProcessor processor;
+    private Entry entry;
+    private Task task;
+    private ImmutableRuleset netex2gtfsRuleset;
+
+    @BeforeEach
+    void setUp() {
+        VacoProperties vacoProperties = TestObjects.vacoProperties();
+        processor = new RuleResultProcessor(vacoProperties, packagesService, s3Client, taskService, findingService, rulesetService, new ObjectMapper()) {
+            @Override
+            boolean doProcessResults(ResultMessage resultMessage, Entry entry, Task task, Map<String, String> fileNames) {
+                return false;
+            }
+        };
+        entry = entryWithTask(e -> ImmutableTask.of(RuleName.NETEX2GTFS_ENTUR, 100)
+            .withId(9_000_000L)
+            .withPublicId(NanoIdUtils.randomNanoId()));
+        task = entry.tasks().get(0);
+        netex2gtfsRuleset = ImmutableRuleset.of(
+                RuleName.NETEX2GTFS_ENTUR,
+                "netex2gtfs",
+                Category.GENERIC,
+                RulesetType.CONVERSION_SYNTAX,
+                TransitDataFormat.NETEX)
+            .withId(1L);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(rulesetService);
+    }
+
+    // --- isNonErrorLogLine tests ---
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.RouteNameException",
+        "12:00.000 [pool-1] WARN org.foo.Bar -- Something about SomeException handling",
+        "12:00.000 [pool-1] DEBUG org.foo.Bar -- Caught RouteNameException",
+        "12:00.000 [pool-1] TRACE org.foo.Bar -- Exception class loaded",
+        "12:00.000 [main] INFO org.foo.ExceptionMapper -- starting up"
+    })
+    void isNonErrorLogLine_returnsTrue_forNonErrorLevelLinesWithExceptionInContent(String line) {
+        boolean result = RuleResultProcessor.isNonErrorLogLine(line);
+        assertTrue(result, "Expected line to be excluded as non-error: " + line);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "12:00.000 [main] ERROR org.foo.Bar -- SomeException: bad stuff",
+        "java.lang.RuntimeException: something broke",
+        "Caused by: java.io.IOException: file not found",
+        "Exception in thread \"main\" java.lang.OutOfMemoryError",
+        "",
+        "Writing entity RouteNameException"
+    })
+    void isNonErrorLogLine_returnsFalse_forErrorLinesAndStackTraces(String line) {
+        boolean result = RuleResultProcessor.isNonErrorLogLine(line);
+        assertFalse(result, "Expected line NOT to be excluded: " + line);
+    }
+
+    // --- scanErrorLog tests ---
+
+    @Test
+    void scanErrorLog_returnsNoFindings_whenLogIsEmpty(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("empty.log");
+        Files.writeString(logFile, "");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, empty());
+    }
+
+    @Test
+    void scanErrorLog_returnsNoFindings_whenAllExceptionLinesAreInfoLevel(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("info-only.log");
+        Files.writeString(logFile,
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.RouteNameException\n" +
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.DirectionNameException\n" +
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.AlternateStopNameException\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, empty());
+    }
+
+    @Test
+    void scanErrorLog_returnsFinding_whenExceptionLineMixedWithInfoLines(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("mixed.log");
+        Files.writeString(logFile,
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.RouteNameException\n" +
+            "12:00.000 [main] ERROR org.foo.Bar -- SomeException: bad stuff\n" +
+            "23:28.742 [main] INFO org.onebusaway.gtfs.serialization.GtfsWriter -- writing entities: org.onebusaway.gtfs.model.DirectionNameException\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, hasSize(1));
+    }
+
+    @Test
+    void scanErrorLog_returnsFinding_whenErrorLevelExceptionLine(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("error.log");
+        Files.writeString(logFile, "12:00.000 [main] ERROR org.foo.Bar -- BrokenException: failure\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, hasSize(1));
+    }
+
+    @Test
+    void scanErrorLog_returnsFinding_whenUnstructuredExceptionLine(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("unstructured.log");
+        Files.writeString(logFile, "java.lang.NullPointerException: cannot be null\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, hasSize(1));
+    }
+
+    @Test
+    void scanErrorLog_returnsFinding_whenCausedByLine(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("causedby.log");
+        Files.writeString(logFile, "Caused by: java.io.IOException: file not found\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Exception");
+
+        assertThat(findings, hasSize(1));
+    }
+
+    @Test
+    void scanErrorLog_returnsFinding_whenNodeJsErrorLine(@TempDir Path tempDir) throws IOException {
+        Path logFile = tempDir.resolve("nodejs.log");
+        Files.writeString(logFile, "TypeError: Cannot read property 'id' of undefined\n");
+        given(rulesetService.findByName(RuleName.NETEX2GTFS_ENTUR)).willReturn(Optional.of(netex2gtfsRuleset));
+
+        List<ImmutableFinding> findings = processor.scanErrorLog(entry, task, RuleName.NETEX2GTFS_ENTUR, logFile, "Error");
+
+        assertThat(findings, hasSize(1));
+    }
+}


### PR DESCRIPTION
Exclude INFO, DEBUG, TRACE and WARN level logs from the "Järjestelmävirhe" exception scan. The filter excludes structured SLF4J log lines at INFO/WARN/DEBUG/TRACE levels before applying the "Exception" check. ERROR-level lines and unstructured output (bare stack traces, Caused by:, Node.js errors) are still reported as before. The excluded logs will of course still be visible in the full log files. Tests generated by Copilot.

Also removed dead scanLog() method.