### PR TITLE
DPO-4584: fix netex-entur NoSuchFileException

### DIFF
--- a/src/main/java/fi/digitraffic/tis/vaco/rules/internal/DownloadRule.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/internal/DownloadRule.java
@@ -100,7 +100,6 @@ public class DownloadRule implements Rule<Entry, ResultMessage> {
                     String downloadedFilePackage = "result";
                     Map<String, List<String>> uploadedFiles = Map.of();
                     if (result.isPresent()) {
-                        taskService.markStatus(entry, tracked, Status.SUCCESS);
                         S3Path s3Path = result.get();
                         uploadedFiles = Map.of(s3Path.asUri(vacoProperties.s3PackagesBucket()), List.of(downloadedFilePackage));
                     } else {
@@ -174,11 +173,8 @@ public class DownloadRule implements Rule<Entry, ResultMessage> {
             return feedArchive.thenCompose(validateZip(tracked))
                 .thenApply(track(entry, tracked, ProcessingState.UPDATE))
                 .thenCompose(uploadToS3(entry, tracked))
-                .thenApply(track(entry, tracked, ProcessingState.COMPLETE))
                 .join();
         } else {
-            // yes, this looks a bit weird, it's because it reuses the function from above composition
-            track(entry, tracked, ProcessingState.COMPLETE).apply(tracked);
             return Optional.empty();
         }
     }

--- a/src/main/java/fi/digitraffic/tis/vaco/rules/internal/StopsAndQuaysRule.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/internal/StopsAndQuaysRule.java
@@ -59,8 +59,6 @@ public class StopsAndQuaysRule implements Rule<Entry, ResultMessage> {
 
                     s3Client.uploadFile(vacoProperties.s3PackagesBucket(), s3TargetPath, stopsAndQuays).join();
 
-                    taskService.trackTask(entry, t, ProcessingState.COMPLETE);
-
                     return ImmutableResultMessage.builder()
                         .entryId(entry.publicId())
                         .taskId(tracked.id())

--- a/src/main/java/fi/digitraffic/tis/vaco/rules/results/InternalRuleResultProcessor.java
+++ b/src/main/java/fi/digitraffic/tis/vaco/rules/results/InternalRuleResultProcessor.java
@@ -47,8 +47,11 @@ public class InternalRuleResultProcessor extends RuleResultProcessor implements 
         // use downloaded result file as is instead of repackaging the zip
         ConcurrentMap<String, List<String>> packages = collectPackageContents(resultMessage.uploadedFiles());
         if (!packages.containsKey("result") || packages.get("result").isEmpty()) {
-            logger.warn("Entry {} internal task {} does not contain 'result' package.", resultMessage.entryId(), task.name());
-            taskService.markStatus(entry, task, Status.FAILED);
+            // preserve terminal statuses (CANCELLED, FAILED) already set by the rule itself
+            if (Status.isNotCompleted(task.status())) {
+                logger.warn("Entry {} internal task {} does not contain 'result' package.", resultMessage.entryId(), task.name());
+                taskService.markStatus(entry, task, Status.FAILED);
+            }
             taskService.trackTask(entry, task, ProcessingState.COMPLETE);
             return false;
         } else {

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/internal/DownloadRuleTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/internal/DownloadRuleTests.java
@@ -46,6 +46,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -105,8 +107,6 @@ class DownloadRuleTests {
         given(httpClient.downloadFile(tempFilePath.capture(), eq(entry.url()), eq(entry))).willAnswer(a -> CompletableFuture.completedFuture(response));
         given(taskService.trackTask(entry, dlTask, ProcessingState.UPDATE)).willReturn(dlTask);
         given(s3Client.uploadFile(eq(vacoProperties.s3PackagesBucket()), targetPath.capture(), sourcePath.capture())).willReturn(CompletableFuture.completedFuture(null));
-        given(taskService.trackTask(entry, dlTask, ProcessingState.COMPLETE)).willReturn(dlTask);
-        given(taskService.markStatus(entry, dlTask, Status.SUCCESS)).willReturn(dlTask);
 
         ResultMessage result = rule.execute(entry).join();
 
@@ -152,8 +152,6 @@ class DownloadRuleTests {
         given(entryService.updateEtag(entry, newEtag)).willReturn(ImmutableEntry.copyOf(entry).withEtag(newEtag));
         given(taskService.trackTask(entry, dlTask, ProcessingState.UPDATE)).willReturn(dlTask);
         given(s3Client.uploadFile(eq(vacoProperties.s3PackagesBucket()), targetPath.capture() , sourcePath.capture())).willReturn(CompletableFuture.completedFuture(null));
-        given(taskService.trackTask(entry, dlTask, ProcessingState.COMPLETE)).willReturn(dlTask);
-        given(taskService.markStatus(entry, dlTask, Status.SUCCESS)).willReturn(dlTask);
 
         ResultMessage result = rule.execute(entry).join();
 
@@ -180,12 +178,31 @@ class DownloadRuleTests {
         given(taskService.trackTask(entry, dlTask, ProcessingState.START)).willReturn(dlTask);
         given(featureFlagsService.isFeatureFlagEnabled("tasks.prepareDownload.skipDownloadOnStaleETag")).willReturn(true);
         given(entryService.findLatestEntryForContext(entry.businessId(), entry.context())).willReturn(Optional.of(previousEntry));
-        given(taskService.trackTask(entry, dlTask, ProcessingState.COMPLETE)).willReturn(dlTask);
         given(taskService.markStatus(entry, dlTask, Status.CANCELLED)).willReturn(dlTask);
 
         ResultMessage result = rule.execute(entry).join();
 
         assertThat(result.uploadedFiles().isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void marksTaskFailedOnUnrecoverableException() {
+        ImmutableEntry.Builder entryBuilder = TestObjects.anEntry(TransitDataFormat.GTFS.fieldName());
+        Task dlTask = ImmutableTask.of(DownloadRule.PREPARE_DOWNLOAD_TASK, -1).withId(5000000L).withPublicId(NanoIdUtils.randomNanoId());
+        Entry entry = entryBuilder.addTasks(dlTask).build();
+
+        given(taskService.findTask(entry.publicId(), DownloadRule.PREPARE_DOWNLOAD_TASK)).willReturn(Optional.of(dlTask));
+        given(taskService.trackTask(entry, dlTask, ProcessingState.START)).willReturn(dlTask);
+        given(featureFlagsService.isFeatureFlagEnabled("tasks.prepareDownload.skipDownloadOnStaleETag")).willReturn(true);
+        given(httpClient.downloadFile(any(Path.class), eq(entry.url()), eq(entry)))
+            .willReturn(CompletableFuture.failedFuture(new RuntimeException("connection refused")));
+        given(taskService.markStatus(entry, dlTask, Status.FAILED)).willReturn(dlTask);
+
+        ResultMessage result = rule.execute(entry).join();
+
+        assertThat(result.uploadedFiles().isEmpty(), equalTo(true));
+        verify(taskService).markStatus(entry, dlTask, Status.FAILED);
+        verify(taskService, never()).trackTask(entry, dlTask, ProcessingState.COMPLETE);
     }
 
     @NotNull

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/internal/StopsAndQuaysRuleTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/internal/StopsAndQuaysRuleTests.java
@@ -29,6 +29,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,12 +69,26 @@ class StopsAndQuaysRuleTests {
         given(taskService.findTask(entry.publicId(), StopsAndQuaysRule.PREPARE_STOPS_AND_QUAYS_TASK)).willReturn(Optional.of(saqTask));
         given(taskService.trackTask(entry, saqTask, ProcessingState.START)).willReturn(saqTask);
         given(s3Client.uploadFile(eq(vacoProperties.s3PackagesBucket()), targetPath.capture(), sourcePath.capture())).willReturn(CompletableFuture.completedFuture(null));
-        given(taskService.trackTask(entry, saqTask, ProcessingState.COMPLETE)).willReturn(saqTask);
 
         ResultMessage result = rule.execute(entry).join();
 
         assertThat(result.ruleName(), equalTo(StopsAndQuaysRule.PREPARE_STOPS_AND_QUAYS_TASK));
 
         assertThat(targetPath.getValue().toString(), equalTo( entry.publicId() + "/" + saqTask.publicId() + "/stopsAndQuays.zip"));
+    }
+
+    @Test
+    void doesNotMarkTaskCompleteDirectly() {
+        ImmutableEntry.Builder entryBuilder = TestObjects.anEntry("gtfs");
+        Task saqTask = ImmutableTask.of(StopsAndQuaysRule.PREPARE_STOPS_AND_QUAYS_TASK, -1).withId(5000000L).withPublicId(NanoIdUtils.randomNanoId());
+        Entry entry = entryBuilder.addTasks(saqTask).build();
+
+        given(taskService.findTask(entry.publicId(), StopsAndQuaysRule.PREPARE_STOPS_AND_QUAYS_TASK)).willReturn(Optional.of(saqTask));
+        given(taskService.trackTask(entry, saqTask, ProcessingState.START)).willReturn(saqTask);
+        given(s3Client.uploadFile(eq(vacoProperties.s3PackagesBucket()), targetPath.capture(), sourcePath.capture())).willReturn(CompletableFuture.completedFuture(null));
+
+        rule.execute(entry).join();
+
+        verify(taskService, never()).trackTask(entry, saqTask, ProcessingState.COMPLETE);
     }
 }

--- a/src/test/java/fi/digitraffic/tis/vaco/rules/results/InternalRuleResultProcessorTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/rules/results/InternalRuleResultProcessorTests.java
@@ -31,6 +31,8 @@ import static fi.digitraffic.tis.vaco.rules.ResultProcessorTestHelpers.entryWith
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -81,6 +83,32 @@ class InternalRuleResultProcessorTests extends ResultProcessorTestBase {
 
     private void givenPackageIsRegistered() {
         given(packagesService.registerPackage(registeredPackage.capture())).willAnswer(i -> i.getArgument(0));
+    }
+
+    @Test
+    void preservesCancelledStatusWhenNoResultPackage() {
+        Task cancelledTask = ImmutableTask.copyOf(downloadTask).withStatus(Status.CANCELLED);
+        ResultMessage emptyResult = asResultMessage(vacoProperties, DownloadRule.PREPARE_DOWNLOAD_TASK, entry, Map.of());
+
+        givenTaskProcessingStateIsMarkedAs(entry, cancelledTask, ProcessingState.COMPLETE);
+
+        boolean result = resultProcessor.processResults(emptyResult, entry, cancelledTask);
+
+        assertThat(result, equalTo(false));
+        verify(taskService, never()).markStatus(entry, cancelledTask, Status.FAILED);
+    }
+
+    @Test
+    void marksFailedWhenNoResultPackageAndStatusNotTerminal() {
+        ResultMessage emptyResult = asResultMessage(vacoProperties, DownloadRule.PREPARE_DOWNLOAD_TASK, entry, Map.of());
+
+        givenTaskStatusIsMarkedAs(entry, Status.FAILED);
+        givenTaskProcessingStateIsMarkedAs(entry, downloadTask, ProcessingState.COMPLETE);
+
+        boolean result = resultProcessor.processResults(emptyResult, entry, downloadTask);
+
+        assertThat(result, equalTo(false));
+        verify(taskService).markStatus(entry, downloadTask, Status.FAILED);
     }
 
 }

--- a/src/test/java/fi/digitraffic/tis/vaco/validation/RulesetSubmissionServiceIntegrationTests.java
+++ b/src/test/java/fi/digitraffic/tis/vaco/validation/RulesetSubmissionServiceIntegrationTests.java
@@ -20,6 +20,7 @@ import fi.digitraffic.tis.vaco.rules.RuleName;
 import fi.digitraffic.tis.vaco.rules.internal.DownloadRule;
 import fi.digitraffic.tis.vaco.rules.model.ResultMessage;
 import fi.digitraffic.tis.vaco.rules.model.ValidationRuleJobMessage;
+import fi.digitraffic.tis.vaco.rules.results.InternalRuleResultProcessor;
 import fi.digitraffic.tis.vaco.ruleset.RulesetService;
 import fi.digitraffic.tis.vaco.ruleset.model.Category;
 import fi.digitraffic.tis.vaco.ruleset.model.TransitDataFormat;
@@ -79,6 +80,9 @@ class RulesetSubmissionServiceIntegrationTests extends SpringBootIntegrationTest
     @Autowired
     private DownloadRule downloadRule;
 
+    @Autowired
+    private InternalRuleResultProcessor internalRuleResultProcessor;
+
     Path response;
 
     @Autowired
@@ -115,6 +119,11 @@ class RulesetSubmissionServiceIntegrationTests extends SpringBootIntegrationTest
 
         String testQueueName = createSqsQueue(MessageQueue.RULE_PROCESSING.munge(RuleName.GTFS_CANONICAL));
         ResultMessage downloadedFile = downloadRule.execute(entry).join();
+
+        // Process the result through InternalRuleResultProcessor to register packages and mark task complete,
+        // to simulate the full SQS pipeline that runs in production
+        Task downloadTask = taskService.findTask(entry.publicId(), DownloadRule.PREPARE_DOWNLOAD_TASK).get();
+        internalRuleResultProcessor.processResults(downloadedFile, entry, downloadTask);
 
         Task task = taskService.findTask(entry.publicId(), RuleName.GTFS_CANONICAL).get();
         rulesetSubmissionService.submitTask(
@@ -155,6 +164,11 @@ class RulesetSubmissionServiceIntegrationTests extends SpringBootIntegrationTest
 
         String testQueueName = createSqsQueue(MessageQueue.RULE_PROCESSING.munge(RuleName.GTFS_CANONICAL));
         ResultMessage downloadedFile = downloadRule.execute(entry).join();
+
+        // Process the result through InternalRuleResultProcessor to register packages and mark task complete,
+        // to simulate the full SQS pipeline that runs in production
+        Task downloadTask = taskService.findTask(entry.publicId(), DownloadRule.PREPARE_DOWNLOAD_TASK).get();
+        internalRuleResultProcessor.processResults(downloadedFile, entry, downloadTask);
 
         Task task = taskService.findTask(entry.publicId(), RuleName.GTFS_CANONICAL).get();
         rulesetSubmissionService.submitTask(


### PR DESCRIPTION
`DownloadRule` marked tasks as `COMPLETE` in the database before `InternalRuleResultProcessor` registered the package. When a concurrent delegation round (triggered by e.g. prepare.stopsAndQuays completing first) saw the download task as "done", it tried to copy netex.zip to the next rule's input — but the package wasn't registered yet, so the file was silently skipped. This caused netex.entur to fail with NoSuchFileException.

Fix: Remove premature `COMPLETE`/`SUCCESS` tracking from `DownloadRule` and `StopsAndQuaysRule`. Now only `InternalRuleResultProcessor` marks internal tasks as complete  after registering the package.

Fancy graphic by Copilot that maybe explains this better:
```
Before (race condition):

  DownloadRule                              SQS round-trip              InternalRuleResultProcessor
  ├─ upload to S3                           │                           │
  ├─ track(COMPLETE) ← task visible as done │                           │
  ├─ send ResultMessage ──────────────────► │                           │
  │                                         │ ~~~ SQS latency ~~~       │
  │                                         ├──────────────────────────►│
  │                                         │                           ├─ registerPackage() ← too late
  │                                         │                           └─ track(COMPLETE)
  │
  └─ Meanwhile: another task completes, triggers delegation round
     └─ sees download task COMPLETE → tries to copy netex.zip → NOT REGISTERED YET → silent skip
        └─ netex.entur starts without input → NoSuchFileException


After (fix):

  DownloadRule                              SQS round-trip              InternalRuleResultProcessor
  ├─ upload to S3                           │                           │
  ├─ send ResultMessage ──────────────────► │                           │
  │   (task NOT marked complete yet)        │ ~~~ SQS latency ~~~       │
  │                                         ├──────────────────────────►│
  │                                         │                           ├─ registerPackage()
  │                                         │                           └─ track(COMPLETE) ← now safe
  │
  └─ Meanwhile: delegation round sees task NOT complete → waits
```