### PR TITLE
fix: switch to spring-boot-starter-parent so CVE version pins take effect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
         <maven>3.9.0</maven>
     </prerequisites>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.14</version>
+    </parent>
+
     <properties>
         <!-- versions for all dependencies which support BOMs, see also dependencyManagement -->
         <java.version>21</java.version>
@@ -42,7 +48,6 @@
         <netty.version>4.1.134.Final</netty.version> <!-- critical CVE-2026-42581, CVE-2026-42579, CVE-2026-42584 and high CVE-2026-42583, CVE-2026-42577, CVE-2026-42578, CVE-2026-42585, CVE-2026-42587 et al. -->
         <postgresql.version>42.7.11</postgresql.version> <!-- high GHSA-98qh-xjc8-98pq, CVE-2026-42198 -->
         <tomcat.version>10.1.55</tomcat.version> <!-- critical GHSA-r29c-68gh-xp6x, GHSA-h6fc-48rj-7qqh, GHSA-5m62-pw8w-7w9f and high CVE-2026-34483 et al. -->
-        <testcontainers.version>2.0.4</testcontainers.version>
         <awssdk.version>2.20.139</awssdk.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <awspringcloud.version>3.1.1</awspringcloud.version>
@@ -72,20 +77,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${springframework.boot-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- NOTE: This is order dependent, AWS SDK must be before Spring Cloud AWS.
                        See https://docs.awspring.io/spring-cloud-aws/docs/3.0.1/reference/html/index.html#choosing-aws-sdk-version
             -->


### PR DESCRIPTION
Makes it simpler to set versions for individual components.