### PR TITLE
fix: use eclipse-temurin:25-jre as Jib base image (distroless has no java25 image)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,9 +448,9 @@
                         <image>${jib-maven-plugin.image-name}</image>
                     </to>
                     <from>
-                        <!-- base image is not set to specific artifact id to allow for rolling updates to be taken into
-                             use automatically -->
-                        <image>gcr.io/distroless/java25-debian12</image>
+                        <!-- distroless does not yet provide a java25 image; switch to Eclipse Temurin JRE.
+                             Not pinned to a specific digest to allow rolling security updates. -->
+                        <image>eclipse-temurin:25-jre</image>
                     </from>
                     <extraDirectories>
                         <paths>


### PR DESCRIPTION
## Problem

The CI build fails after the Spring Boot 4 / Java 25 upgrade because `gcr.io/distroless/java25-debian12:latest` returns 404. The distroless project has not published a Java 25 image yet.

## Fix

Switch the Jib base image to `eclipse-temurin:25-jre`, which is available on Docker Hub and is a widely used minimal JRE image. The image is not pinned to a specific digest so it will continue to pick up security patch releases automatically.

## Testing

CI should pass with this change.