### PR TITLE
fix: switch Jib base image to gcr.io/distroless/java25-debian13:nonroot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,9 +435,7 @@
                 <configuration>
                     <container>
                         <mainClass>fi.digitraffic.tis.vaco.VacoApplication</mainClass>
-                        <!-- use numeric UID/GID to avoid group name resolution failures on ECS Fargate;
-                             65534 is "nobody" on both distroless and Ubuntu-based images -->
-                        <user>65534:65534</user>
+                        <user>nobody:nobody</user>
                         <jvmFlags>
                             <!-- force JVM to exit on OOME, needed due to Spring Scheduler's internals catching Errors -->
                             <jvmFlag>-XX:+ExitOnOutOfMemoryError</jvmFlag>
@@ -450,9 +448,8 @@
                         <image>${jib-maven-plugin.image-name}</image>
                     </to>
                     <from>
-                        <!-- distroless does not yet provide a java25 image; switch to Eclipse Temurin JRE.
-                             Not pinned to a specific digest to allow rolling security updates. -->
-                        <image>eclipse-temurin:25-jre</image>
+                        <!-- java25 is on debian13 (Trixie); debian12 only goes up to java21 -->
+                        <image>gcr.io/distroless/java25-debian13:nonroot</image>
                     </from>
                     <extraDirectories>
                         <paths>

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,9 @@
                 <configuration>
                     <container>
                         <mainClass>fi.digitraffic.tis.vaco.VacoApplication</mainClass>
-                        <user>nobody:nobody</user> <!-- "homeless" Linux default user -->
+                        <!-- use numeric UID/GID to avoid group name resolution failures on ECS Fargate;
+                             65534 is "nobody" on both distroless and Ubuntu-based images -->
+                        <user>65534:65534</user>
                         <jvmFlags>
                             <!-- force JVM to exit on OOME, needed due to Spring Scheduler's internals catching Errors -->
                             <jvmFlag>-XX:+ExitOnOutOfMemoryError</jvmFlag>


### PR DESCRIPTION
## Problem

PR #513 fixed the broken build by switching to `eclipse-temurin:25-jre`, but deploying to ECS still fails:

```
CannotStartContainerError: ResourceInitializationError: unable to create new container:
mount callback failed on /tmp: no groups found
```

## Root cause

`gcr.io/distroless/java25-debian12` doesn't exist — Java 25 in distroless is published on **debian13** (Trixie), not debian12.

## Fix

Switch base image to `gcr.io/distroless/java25-debian13:nonroot`. This:
- Keeps the distroless security posture (smaller, minimal attack surface)
- Fixes the ECS Fargate mount error (distroless's `/etc/group` resolves `nobody:nobody` correctly)
- Is 470MB vs 580MB with eclipse-temurin